### PR TITLE
Add remaining time calculator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ python positive_hourly_messages.py
 ```
 
 프로그램 실행 후 `HH:MM` 형식으로 퇴근 시각을 입력하면 현재 시각부터 입력한 시각까지 한 시간 간격으로 랜덤한 메시지가 터미널에 표시됩니다.
+
+`time_until_off.py` 스크립트는 퇴근 예정 시간을 입력하면 남은 시간을 시각적으로 보여줍니다.
+
+```bash
+python time_until_off.py
+```
+
+`HH:MM` 형식의 시간을 입력하면 지금부터 그때까지 남은 시간이 `X시간 Y분` 형태로 출력됩니다.

--- a/tests/test_time_until_off.py
+++ b/tests/test_time_until_off.py
@@ -1,0 +1,19 @@
+import datetime as dt
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from time_until_off import parse_end_time, time_until
+
+
+def test_time_until_same_day():
+    now = dt.datetime(2023, 1, 1, 17, 15)
+    delta = time_until("18:30", now)
+    assert delta == dt.timedelta(hours=1, minutes=15)
+
+
+def test_time_until_next_day():
+    now = dt.datetime(2023, 1, 1, 17, 15)
+    delta = time_until("16:00", now)
+    assert delta == dt.timedelta(hours=22, minutes=45)

--- a/time_until_off.py
+++ b/time_until_off.py
@@ -1,0 +1,42 @@
+import datetime as dt
+
+
+def parse_end_time(input_str: str, now: dt.datetime | None = None) -> dt.datetime:
+    """Parse the input HH:MM time for today or tomorrow."""
+    if now is None:
+        now = dt.datetime.now()
+    try:
+        end_parts = dt.datetime.strptime(input_str, "%H:%M")
+    except ValueError as exc:
+        raise ValueError("잘못된 형식입니다. 예) 18:30") from exc
+
+    end_time = now.replace(hour=end_parts.hour, minute=end_parts.minute,
+                           second=0, microsecond=0)
+    if end_time <= now:
+        end_time += dt.timedelta(days=1)
+    return end_time
+
+
+def time_until(end_input: str, now: dt.datetime | None = None) -> dt.timedelta:
+    """Return time remaining until the given end time string."""
+    end_time = parse_end_time(end_input, now)
+    if now is None:
+        now = dt.datetime.now()
+    return end_time - now
+
+
+def main() -> None:
+    end_input = input("퇴근 예정 시간(HH:MM)을 입력하세요: ").strip()
+    try:
+        delta = time_until(end_input)
+    except ValueError as e:
+        print(e)
+        return
+
+    hours, remainder = divmod(int(delta.total_seconds()), 3600)
+    minutes = remainder // 60
+    print(f"퇴근까지 {hours}시간 {minutes}분 남았습니다.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `time_until_off.py` to show remaining time before leaving work
- document the new script in README
- add tests for the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684127c976b8832186d760eb18091a54